### PR TITLE
Bump @gravitywelluk/email-generator

### DIFF
--- a/packages/backend/email-generator/package.json
+++ b/packages/backend/email-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gravitywelluk/email-generator",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "keywords": [
     "gravitywell",
     "gravitywelluk",

--- a/packages/backend/email-generator/src/generate-html-email.ts
+++ b/packages/backend/email-generator/src/generate-html-email.ts
@@ -5,7 +5,7 @@ const debug = createDebug("EMAILS:PREPARE-EMAIL");
 /**
  * Populate a html template replacing handlebar style values with your named values
  *
- * @param htmlTemplate The html string template
+ * @param htmlTemplate The html string template with params {%param%}
  * @param emailData The email data to load into the template
  *
  * @returns interpolated email string template
@@ -14,7 +14,7 @@ export const generateHTMLEmail = <D extends Record<string, any>>(htmlTemplate: s
   debug.info("Preparing email", emailData);
 
   let finalTemplate = htmlTemplate;
-  // Matches anything in curly braces {appUrl}, {username} etc.
+  // Matches anything in curly braces with percent symbols {%appUrl%}, {%firstName%} etc.
   const placeholders = htmlTemplate.match(/\{%(.*?)%\}/g);
 
   placeholders?.forEach(placeholder => {


### PR DESCRIPTION
Updated comments
This bump means the dist folder should actually get built (`packages/backend/email-generator` wasn't included in the root tsconfig, was added in the last PR but that didn't trigger a version bump for this package)