### PR TITLE
Hotfix media optimiser

### DIFF
--- a/packages/backend/media-optimiser/README.md
+++ b/packages/backend/media-optimiser/README.md
@@ -25,3 +25,45 @@ Check prerequisites in https://sharp.pixelplumbing.com/install
 Supports reading: JPEG, PNG, WebP, AVIF, TIFF, GIF and SVG images.
 
 Default formats: JPEG, PNG, WebP, AVIF and TIFF.
+
+## On Lambda
+You'll need to deploy a lambda layer with prebuilt  binaries in order to run this package on Lambda.
+
+If using Serverless Stack, then follow these steps to replace the node_modules version of Sharp with a Lambda Layer:
+
+**Build the Layer**
+
+Add a pre-built Sharp layer zip file to your project, somewhere like `layers/sharp`. Use the zip file from [here](https://github.com/Umkus/lambda-layer-sharp/releases) or build your own version with any customisations you need (additional fonts for example).
+
+**Reference the layer in your Lambda**
+
+Then reference the layer in your function. Exclude Sharp by defining it in your `externalModules` and then add your layer. This must be an unzipped folder, so unzip the file as part of your CI flow.
+```js
+const mediaOptimiser = new sst.Function(this, "media-optimiser", {
+      handler: "services/core/src/media-optimiser/media-optimiser.handler",
+      functionName: `${scope.stage}-${scope.name}-media-optimiser`,
+      timeout: 120,
+      bundle: { externalModules: [ "sharp" ] },
+      layers: process.env.ENVIRONMENT !== "development" ? [ new LayerVersion(this, "sharp", { code: Code.fromAsset("layers/sharp") }) ] : undefined,
+      permissions: [
+        "lambda:InvokeFunction",
+        "s3:*",
+        "secretsmanager:GetSecretValue"
+      ]
+    });
+```
+
+To unzip the folder add the following step to your `Jenkinsfile`, after installing dependencies:
+```
+stage("Unzip the Sharp lambda layer") {
+    steps {
+      sh "unzip layers/sharp/nodejs.zip -d layers/sharp"
+    }
+  }
+```
+
+
+To run locally you'll still need sharp on your local machine - this is probably best added to dev dependencies: 
+```
+yarn add -D sharp
+```

--- a/packages/backend/media-optimiser/src/media-optimiser.ts
+++ b/packages/backend/media-optimiser/src/media-optimiser.ts
@@ -26,7 +26,7 @@ export const optimiseMedia = async ({
     375,
     600,
     960,
-    1200
+    1280
   ]
 }: MediaOptimiserAttributes): Promise<any> => {
   const optimisedMedia: OptimisedMedia[] = [];

--- a/packages/backend/media-optimiser/src/media-optimiser.ts
+++ b/packages/backend/media-optimiser/src/media-optimiser.ts
@@ -23,6 +23,7 @@ export const optimiseMedia = async ({
     "jpeg"
   ],
   sizes = [
+    375,
     600,
     960,
     1200
@@ -32,7 +33,7 @@ export const optimiseMedia = async ({
 
   for await (const format of formats) {
     for await (const size of sizes) {
-      const optimisedImage = await sharp(fileBuffer).resize({ width: size }).toFormat(format).toBuffer();
+      const optimisedImage = await sharp(fileBuffer).resize({ width: size }).withMetadata().toFormat(format).toBuffer();
 
       const mediaObj = {
         key: `${format}/${size}/${fileName}.${format}`,


### PR DESCRIPTION
Added Lambda layer instructions to readme
Added 375 width and `withMetadata()` to the optimiser, which will ensure orientation EXIF is kept.