### PR TITLE
Added custom lambda handler

### DIFF
--- a/packages/backend/lambda-utils/src/custom-handler.ts
+++ b/packages/backend/lambda-utils/src/custom-handler.ts
@@ -1,0 +1,48 @@
+import {
+  Context,
+  Callback,
+  Handler
+} from "aws-lambda";
+import * as Sentry from "@sentry/node";
+
+import { LambdaOptions } from "./gateway-proxy-handler";
+
+if (process.env.SENTRY_DSN) {
+  const client = Sentry.getCurrentHub().getClient();
+
+  if (!client) {
+    Sentry.init({ dsn: process.env.SENTRY_DSN });
+  }
+}
+
+/**
+ * Wraps a lambda function with sentry and any other useful stuff.
+ * Useful when for lambdas that will only be invoked directly via another lambda (ie not via user request)
+ *
+ * @param handler
+ */
+export function customHandler<T = Record<string, unknown>>(handler: Handler<T>, options?: Pick<LambdaOptions, "cleanup">) {
+  return async (event: T, context: Context, callback: Callback<void>): Promise<void> => {
+    try {
+      await handler(
+        event, context, callback
+      );
+
+      return;
+    } catch (error) {
+      // flush to send events to sentry
+      if (process.env.SENTRY_DSN) {
+        // flush to send events to sentry
+        await Sentry.flush(2000);
+      }
+
+      if (options?.cleanup) {
+        await options.cleanup();
+      }
+
+      callback(error as Error);
+
+      return;
+    }
+  };
+}

--- a/packages/backend/lambda-utils/src/index.ts
+++ b/packages/backend/lambda-utils/src/index.ts
@@ -8,3 +8,4 @@ export * from "./mock-lambda-context";
 export * from "./cloudfront-request-handler";
 export * from "./scheduled-event-handler";
 export * from "./sqs-event-handler";
+export * from "./custom-handler";


### PR DESCRIPTION
Wraps a lambda function with sentry and any other useful stuff like cleanup options.
Useful when for lambdas that will only be invoked directly via another lambda (ie not via user request or s3 trigger)