### PR TITLE
🏷️ react-square: Allow multiple verification intent types

### DIFF
--- a/.yarn/versions/100b3e96.yml
+++ b/.yarn/versions/100b3e96.yml
@@ -1,0 +1,2 @@
+releases:
+  "@gravitywelluk/react-square": minor

--- a/packages/frontend/react-square/src/index.ts
+++ b/packages/frontend/react-square/src/index.ts
@@ -66,7 +66,12 @@ export interface VerificationDetails {
   /** Currency code e.g. `"GBP"` or `"USD"` */
   currencyCode: string;
   /** What you intend to do with the payment, e.g. `"CHARGE"`, `"STORE"` */
-  intent: "CHARGE"
+  intent: VerificationIntent;
+}
+
+export enum VerificationIntent {
+  Charge = "CHARGE",
+  Store = "STORE"
 }
 
 export interface TokenResult {


### PR DESCRIPTION
The current typings only allow `intent: "CHARGE"` but in some cases we may want `intent: "STORE"`.
This change adds a `VerificationIntent` enum with both options ✨ 