### PR TITLE
Added allowedOrigins in proxy handler

### DIFF
--- a/.yarn/versions/c2c23351.yml
+++ b/.yarn/versions/c2c23351.yml
@@ -1,0 +1,2 @@
+releases:
+  "@gravitywelluk/lambda-utils": minor

--- a/packages/backend/lambda-utils/src/build-api-response.ts
+++ b/packages/backend/lambda-utils/src/build-api-response.ts
@@ -40,7 +40,7 @@ export const buildApiResponse = <D extends unknown>(
         statusCode,
         headers: {
           "Content-Type": "application/json",
-          "Access-Control-Allow-Origin": allowedOrigins[ 0 ],
+          "Access-Control-Allow-Origin": currentOrigin ?? allowedOrigins[ 0 ],
           "Access-Control-Allow-Credentials": true
         },
         body: JSON.stringify({ error: formattedError })

--- a/packages/backend/lambda-utils/src/build-api-response.ts
+++ b/packages/backend/lambda-utils/src/build-api-response.ts
@@ -2,7 +2,10 @@ import {
   APIGatewayProxyResult,
   Context
 } from "aws-lambda";
-import { APIError, ErrorType } from "@gravitywelluk/error";
+import {
+  APIError,
+  ErrorType
+} from "@gravitywelluk/error";
 
 import { CustomAPIGatewayProxyEvent } from "./gateway-proxy-handler";
 
@@ -15,29 +18,29 @@ import { CustomAPIGatewayProxyEvent } from "./gateway-proxy-handler";
    * @param allowedOrigins A collection of origins to allow
    */
 export const buildApiResponse = <D extends unknown>(
-  event: CustomAPIGatewayProxyEvent, _context: Context, data: D | APIError<unknown> | Error, allowedOrigins?: String[]
+  event: CustomAPIGatewayProxyEvent, _context: Context, data: D | APIError<unknown> | Error, allowedOrigins?: string[]
 ): APIGatewayProxyResult => {
-
   if (allowedOrigins) {
     const currentOrigin = event.headers ? event.headers.origin : null;
-
     let isOriginAllowed = false;
+
     // Check if origin is in allowed origins
     allowedOrigins.map(allowedOrigin => {
-      if (!isOriginAllowed && currentOrigin.match(allowedOrigin)) {
+      if (!isOriginAllowed && currentOrigin && currentOrigin.match(allowedOrigin)) {
         isOriginAllowed = true;
       }
-    })
+    });
 
     // Return an error if origin is not allowed or if there's no origin
     if (!isOriginAllowed || !currentOrigin) {
       const error = new APIError("Forbidden - origin not allowed", ErrorType.ForbiddenError);
       const { statusCode, ...formattedError } = APIError.formatApiError(error);
+
       return {
         statusCode,
         headers: {
           "Content-Type": "application/json",
-          "Access-Control-Allow-Origin": allowedOrigins[0],
+          "Access-Control-Allow-Origin": allowedOrigins[ 0 ],
           "Access-Control-Allow-Credentials": true
         },
         body: JSON.stringify({ error: formattedError })
@@ -45,10 +48,9 @@ export const buildApiResponse = <D extends unknown>(
     }
   }
 
-
   const headers = {
     "Content-Type": "application/json",
-    "Access-Control-Allow-Origin": event.headers.origin,
+    "Access-Control-Allow-Origin": event.headers && event.headers.origin ? event.headers.origin : "*",
     "Access-Control-Allow-Credentials": true
   };
 

--- a/packages/backend/lambda-utils/src/build-api-response.ts
+++ b/packages/backend/lambda-utils/src/build-api-response.ts
@@ -25,7 +25,7 @@ export const buildApiResponse = <D extends unknown>(
     let isOriginAllowed = false;
 
     // Check if origin is in allowed origins
-    allowedOrigins.map(allowedOrigin => {
+    allowedOrigins.forEach(allowedOrigin => {
       if (!isOriginAllowed && currentOrigin && currentOrigin.match(allowedOrigin)) {
         isOriginAllowed = true;
       }
@@ -40,7 +40,7 @@ export const buildApiResponse = <D extends unknown>(
         statusCode,
         headers: {
           "Content-Type": "application/json",
-          "Access-Control-Allow-Origin": currentOrigin ?? allowedOrigins[ 0 ],
+          "Access-Control-Allow-Origin": allowedOrigins[ 0 ],
           "Access-Control-Allow-Credentials": true
         },
         body: JSON.stringify({ error: formattedError })

--- a/packages/backend/lambda-utils/src/gateway-proxy-handler.ts
+++ b/packages/backend/lambda-utils/src/gateway-proxy-handler.ts
@@ -32,7 +32,7 @@ export interface LambdaOptions {
   preRequest?: (event: CustomAPIGatewayProxyEvent, context: Context) => Promise<void>;
   /** Runs at end of lambda - does not stop the lambda processing */
   cleanup?: () => Promise<void>;
-  allowedOrigins?: String[];
+  allowedOrigins?: string[];
 }
 /**
  * Wraps a lambda function so that we can return static JSONAPI response objects

--- a/packages/backend/lambda-utils/src/gateway-proxy-handler.ts
+++ b/packages/backend/lambda-utils/src/gateway-proxy-handler.ts
@@ -32,6 +32,7 @@ export interface LambdaOptions {
   preRequest?: (event: CustomAPIGatewayProxyEvent, context: Context) => Promise<void>;
   /** Runs at end of lambda - does not stop the lambda processing */
   cleanup?: () => Promise<void>;
+  allowedOrigins?: String[];
 }
 /**
  * Wraps a lambda function so that we can return static JSONAPI response objects
@@ -80,9 +81,9 @@ export const gatewayProxyHandler = <TResult = unknown>(handler: APIGatewayProxyH
         await options.cleanup();
       }
 
-      return buildApiResponse<TResult>(event, context, result);
+      return buildApiResponse<TResult>(event, context, result, options?.allowedOrigins);
     } catch (error) {
-      const responseError = buildApiResponse<TResult>(event, context, error as Error);
+      const responseError = buildApiResponse<TResult>(event, context, error as Error, options?.allowedOrigins);
 
       // flush to send events to sentry
       if (process.env.SENTRY_DSN) {


### PR DESCRIPTION
We should only allow specific origins - we are currently allowing all origins.
- passing a list of allowed origins in our gateway proxy handler.
- Only allowing current origin  if it matches any of the allowed origins
- Returning an error if current origin is null or if it's not listed in the passed allowed origins.