### PR TITLE
🔖 Error Package v2

### DIFF
--- a/.yarn/versions/7b46ed13.yml
+++ b/.yarn/versions/7b46ed13.yml
@@ -1,0 +1,2 @@
+releases:
+  "@gravitywelluk/error": major

--- a/packages/backend/error/README.md
+++ b/packages/backend/error/README.md
@@ -10,6 +10,51 @@
 
 ## Usage
 
+### v2
+
+The package allows you to throw consistent errors within your project, without worrying about specific HTTP status codes.
+
+Every HTTP status code (except "I'm a teapot") is available to use, mapped with the `ErrorType` enum. Each enum value is documented with the MDN annotation for the code, to provide an easy view on the code's intended purpose.
+
+#### Example usage
+```typescript
+
+throw new APIError(ErrorType.Forbidden, "User is not permitted to access this resource");
+
+```
+
+#### Migrating from v1
+
+:warning: v2 introduces breaking changes - some work will need to be done if you want to use v2 for a project currently using v1.
+
+v2 moves away from custom project error codes, instead including all available HTTP status codes to select from. The syntax has been slightly adjusted to improve readability.
+
+1. Remove custom `ErrorCode` setup (as shown below) and generics. If you still want to have a project-named error, it will now be a simple extension:
+
+```typescript
+export default class CustomProjectError extends ApiError{}
+```
+
+2. Swap out the currently used `ErrorType` values for those now supported in v2. The naming of these is different, so you may need to refer to the internals of v1 to understand the original error type mappings and convert.
+
+3. Refactor the `ApiError` calls to use the new param order, as shown in the example usage above.
+
+#### Example error api response format
+
+```json
+{
+  "statusCode": 404,
+  "body": {
+    "error": {
+      "message": "User not found",
+      "type": "Forbidden"
+    }
+  }
+}
+```
+
+### v1
+
 Within your project you can specify the more project specific error codes, (see the example below)
 
 ```typescript
@@ -35,7 +80,7 @@ throw new DecarbError(
 );
 ```
 
-## Example error api response format
+#### Example error api response format
 
 ```json
 {

--- a/packages/backend/error/src/api-error.ts
+++ b/packages/backend/error/src/api-error.ts
@@ -1,47 +1,37 @@
 import { createDebug } from "@gravitywelluk/debug";
 
+import { ErrorType } from "./error-type";
+
 const debug = createDebug("ERROR");
 
-/** Available error codes */
-export enum ErrorType {
-  ApiError = "API_ERROR",
-  ApiConectionError = "API_CONNECTION_ERROR",
-  AuthenticationError = "AUTHENTICATION_ERROR",
-  ForbiddenError = "FORBIDDEN_ERROR",
-  InvalidData = "INVALID_DATA_ERROR",
-  DatabaseError = "DATABASE_ERROR",
-  NotFoundError = "NOT_FOUND_ERROR",
-  ThirdPartyError = "THIRD_PARTY_ERROR",
-  TooManyRequests = "TOO_MANY_REQUESTS",
-  UnknownError = "UNKNOWN_ERROR"
-}
-
-export interface ApiErrorResponse<C = unknown> {
-  /** Api response code */
-  statusCode: number;
-  /** Generic error type */
-  type: ErrorType;
+export interface ApiErrorResponse {
+  /** HTTP status code */
+  statusCode: ErrorType;
+  /** Title of HTTP status code */
+  title: string;
+  /** User-facing error message */
   message: string;
-  /** More specific error code, types specified from parent */
-  code?: C;
-  /** Extra more specific relevant information */
-  param?: Record<string, unknown>;
+  /** Additional relevant error details */
+  detail?: string;
 }
 
 /**
- * Standardised api error class
+ * API Error class, storing error type, message and additional details
  */
-export default class APIError<C> extends Error {
+export default class APIError extends Error {
   public readonly type: ErrorType;
-  public readonly code?: C;
-  public readonly param?: Record<string, unknown>;
+  public readonly detail?: string;
 
-  constructor(msg: string, type?: ErrorType, code?: C, param?: Record<string, unknown>) {
+  /**
+   * @param type The type of error to throw - each of these maps to a distinct HTTP status code
+   * @param msg The user-facing error message
+   * @param detail Any additional details about the error
+   */
+  constructor(type: ErrorType, msg: string, detail?: string) {
     super(msg);
-    debug.error(msg, type, code, param);
-    this.type = type || ErrorType.UnknownError;
-    this.code = code;
-    this.param = param;
+    debug.error(msg, type);
+    this.type = type;
+    this.detail = detail;
   }
 
   /**
@@ -49,51 +39,12 @@ export default class APIError<C> extends Error {
    *
    * @param error - The ApiError to output
    */
-  public static formatApiError(error: APIError<unknown>): ApiErrorResponse {
-    const statusCode = this.errorTypeToHttpStatusCode(error.type);
-
+  public static formatApiError(error: APIError): ApiErrorResponse {
     return {
-      statusCode,
+      statusCode: error.type,
+      title: ErrorType[ error.type ],
       message: error.message,
-      type: error.type,
-      code: error.code,
-      param: error.param
+      detail: error.detail
     };
-  }
-
-  /**
-   * Returns a HTTP statusCode according to the given ErrorType
-   *
-   * @param errorType - An ApiError ErrorType
-   */
-  protected static errorTypeToHttpStatusCode(errorType: ErrorType): number {
-    switch (errorType) {
-      case ErrorType.ThirdPartyError:
-      case ErrorType.ApiError:
-      case ErrorType.DatabaseError:
-        return 400;
-
-      case ErrorType.AuthenticationError:
-        return 401;
-
-      case ErrorType.ForbiddenError:
-        return 403;
-
-      case ErrorType.NotFoundError:
-        return 404;
-
-      case ErrorType.InvalidData:
-        return 422;
-
-      case ErrorType.TooManyRequests:
-        return 429;
-
-      case ErrorType.ApiConectionError:
-        return 502;
-
-      case ErrorType.UnknownError:
-      default:
-        return 500;
-    }
   }
 }

--- a/packages/backend/error/src/error-type.ts
+++ b/packages/backend/error/src/error-type.ts
@@ -1,0 +1,149 @@
+/**
+ * The type of the error to be thrown. Each name corresponds to a distinct HTTP status code, as documented [here](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status)
+ */
+export enum ErrorType {
+  /**
+   * 400: The server cannot or will not process the request due to something that is perceived to be a client error (e.g., malformed request syntax, invalid request message framing, or deceptive request routing).
+   */
+  BadRequest = 400,
+  /**
+   * 401: The client must authenticate itself to get the requested response.
+   */
+  Unauthorized = 401,
+  /**
+   * [Experimental] 402: A digital payment is required to proceed.
+   */
+  PaymentRequired = 402,
+  /**
+   * 403: The client does not have access rights to the content; that is, it is unauthorized, so the server is refusing to give the requested resource. Unlike 401 Unauthorized, the client's identity is known to the server.
+   */
+  Forbidden = 403,
+  /**
+   * The server cannot find the requested resource. In the browser, this means the URL is not recognized. In an API, this can also mean that the endpoint is valid but the resource itself does not exist. Servers may also send this response instead of 403 Forbidden to hide the existence of a resource from an unauthorized client.
+   */
+  NotFound = 404,
+  /**
+   * The request method is known by the server but is not supported by the target resource. For example, an API may not allow calling DELETE to remove a resource.
+   */
+  MethodNotAllowed = 405,
+  /**
+   * This response is sent when the web server, after performing server-driven content negotiation, doesn't find any content that conforms to the criteria given by the user agent.
+   */
+  NotAcceptable = 406,
+  /**
+   * This is similar to 401 Unauthorized but authentication is needed to be done by a proxy.
+   */
+  ProxyAuthenticationRequired = 407,
+  /**
+   * The server would like to shut down this unused connection.
+   */
+  RequestTimeout = 408,
+  /**
+   * This response is sent when a request conflicts with the current state of the server.
+   */
+  Conflict = 409,
+  /**
+   * This response is sent when the requested content has been permanently deleted from server, with no forwarding address.
+   */
+  Gone = 410,
+  /**
+   * Server rejected the request because the Content-Length header field is not defined and the server requires it.
+   */
+  LengthRequired = 411,
+  /**
+   * The client has indicated preconditions in its headers which the server does not meet.
+   */
+  PreconditionFailed = 412,
+  /**
+   * Request entity is larger than limits defined by server. The server might close the connection or return an Retry-After header field.
+   */
+  PayloadTooLarge = 413,
+  /**
+   * The URI requested by the client is longer than the server is willing to interpret.
+   */
+  URITooLong = 414,
+  /**
+   * The media format of the requested data is not supported by the server, so the server is rejecting the request.
+   */
+  UnsupportedMediaType = 415,
+  /**
+   * The range specified by the Range header field in the request cannot be fulfilled. It's possible that the range is outside the size of the target URI's data.
+   */
+  RangeNotSatisfiable = 416,
+  /**
+   * This response code means the expectation indicated by the Expect request header field cannot be met by the server.
+   */
+  ExpectationFailed = 417,
+  /**
+   * The request was well-formed but was unable to be followed due to semantic errors.
+   */
+  UnprocessableEntity = 422,
+  /**
+   * Indicates that the server is unwilling to risk processing a request that might be replayed.
+   */
+  TooEarly = 425,
+  /**
+   * The server refuses to perform the request using the current protocol but might be willing to do so after the client upgrades to a different protocol. The server sends an Upgrade header in a 426 response to indicate the required protocol(s).
+   */
+  UpgradeRequired = 426,
+  /**
+   * The origin server requires the request to be conditional. This response is intended to prevent the 'lost update' problem, where a client GETs a resource's state, modifies it and PUTs it back to the server, when meanwhile a third party has modified the state on the server, leading to a conflict.
+   */
+  PreconditionRequired = 428,
+  /**
+   * The user has sent too many requests in a given amount of time ("rate limiting").
+   */
+  TooManyRequests = 429,
+  /**
+   * The server is unwilling to process the request because its header fields are too large. The request may be resubmitted after reducing the size of the request header fields.
+   */
+  RequestHeaderFieldsTooLarge = 431,
+  /**
+   * The user agent requested a resource that cannot legally be provided, such as a web page censored by a government.
+   */
+  UnavailableForLegalReasons = 451,
+  /**
+   * The server has encountered a situation it does not know how to handle.
+   */
+  InternalServerError = 500,
+  /**
+   * The request method is not supported by the server and cannot be handled. The only methods that servers are required to support (and therefore that must not return this code) are GET and HEAD.
+   */
+  NotImplemented = 501,
+  /**
+   * This error response means that the server, while working as a gateway to get a response needed to handle the request, got an invalid response.
+   */
+  BadGateway = 502,
+  /**
+   * The server is not ready to handle the request. Common causes are a server that is down for maintenance or that is overloaded.
+   */
+  ServiceUnavailable = 503,
+  /**
+   * This error response is given when the server is acting as a gateway and cannot get a response in time.
+   */
+  GatewayTimeout = 504,
+  /**
+   * The HTTP version used in the request is not supported by the server.
+   */
+  HTTPVersionNotSupported = 505,
+  /**
+   * The server has an internal configuration error: the chosen variant resource is configured to engage in transparent content negotiation itself, and is therefore not a proper end point in the negotiation process.
+   */
+  VariantAlsoNegotiates = 506,
+  /**
+   * The method could not be performed on the resource because the server is unable to store the representation needed to successfully complete the request.
+   */
+  InsufficientStorage = 507,
+  /**
+   * The server detected an infinite loop while processing the request.
+   */
+  LoopDetected = 508,
+  /**
+   * Further extensions to the request are required for the server to fulfill it.
+   */
+  NotExtended = 510,
+  /**
+   * Indicates that the client needs to authenticate to gain network access.
+   */
+  NetworkAuthenticationRequired = 511
+}

--- a/packages/backend/error/src/index.ts
+++ b/packages/backend/error/src/index.ts
@@ -1,4 +1,5 @@
-import APIError, { ErrorType } from "./api-error";
+import APIError from "./api-error";
+import { ErrorType } from "./error-type";
 
 export {
   APIError,


### PR DESCRIPTION
_Finally_ managed a refactor of the errors package! 🦞 

Aims for v2 were to:
* Improve transparency of mapping from error type to status code
* Support all HTTP error codes
* Improve documentation

Hence the new version, which:

** Demonstrates clear connection between `ErrorType`s and status codes**

The new `ErrorType` enum maps names (e.g. Forbidden, TooManyRequests) to specific status codes. The enum values have a 1:1 mapping to status codes, reducing naming confusion and increasing transparency. A user can hover over an `ErrorType` value and immediately see the corresponding status code.

**Includes all HTTP error codes by default**

The `ErrorType` enum has been refactored to include every 4xx and 5xx HTTP status code - except "I'm a teapot" 🫖 .

** Provides improved documentation **

The OpenAPI comments have been improved, adding clarity to usage. Every status code in the `ErrorType` enum has a comment from the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status) clarifying its usage. The README has been updated with example usage for v2 and a migration guide.