### PR TITLE
Ignore X-Ray errors

### DIFF
--- a/.yarn/versions/c86c5e57.yml
+++ b/.yarn/versions/c86c5e57.yml
@@ -1,0 +1,2 @@
+releases:
+  "@gravitywelluk/aws": patch

--- a/packages/backend/aws/src/lambda/lambda-configure.ts
+++ b/packages/backend/aws/src/lambda/lambda-configure.ts
@@ -3,9 +3,9 @@ import * as AWSModule from "aws-sdk";
 
 import { awsConfigure } from "../utils";
 
-const AWS = AWSXRay.captureAWS(AWSModule);
-
 AWSXRay.setContextMissingStrategy("IGNORE_ERROR");
+
+const AWS = AWSXRay.captureAWS(AWSModule);
 
 /**
  * Creates a new AWS Lambda service object

--- a/packages/backend/aws/src/lambda/lambda-configure.ts
+++ b/packages/backend/aws/src/lambda/lambda-configure.ts
@@ -5,6 +5,8 @@ import { awsConfigure } from "../utils";
 
 const AWS = AWSXRay.captureAWS(AWSModule);
 
+AWSXRay.setContextMissingStrategy("IGNORE_ERROR");
+
 /**
  * Creates a new AWS Lambda service object
  *


### PR DESCRIPTION
X-Ray logs are coming through constantly on Qrone in dev, meaning that finding real errors in the logs is a pain.

Updated the log config to ignore rather than log errors